### PR TITLE
Change build to Python 2.7

### DIFF
--- a/C++/AlbusIonosphere/python_attempt/pyinp.py
+++ b/C++/AlbusIonosphere/python_attempt/pyinp.py
@@ -1,3 +1,4 @@
+from __future__ import (division,print_function)
 import AlbusIonosphere
 AlbusIonosphere.set_ionosphere_IRI(1E-4,1E-3)
 AlbusIonosphere.set_reference_time(2005,3,21,0,0,0)
@@ -7,10 +8,10 @@ AlbusIonosphere.set_time_step(30)
 AlbusIonosphere.set_scan_times(43000,43500)
 AlbusIonosphere.get_Num_Ionospheric_Predictions()
 AlbusIonosphere.get_ionospheric_prediction(0)    
-for i in xrange(AlbusIonosphere.get_Num_Ionospheric_Predictions()):
+for i in range(AlbusIonosphere.get_Num_Ionospheric_Predictions()):
     result = AlbusIonosphere.get_ionospheric_prediction(i)
-    print result
+    print(result)
 AlbusIonosphere.set_scan_times(20000,23200)
-for i in xrange(AlbusIonosphere.get_Num_Ionospheric_Predictions()):
+for i in range(AlbusIonosphere.get_Num_Ionospheric_Predictions()):
     result = AlbusIonosphere.get_ionospheric_prediction(i)
-    print result
+    print(result)

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,28 +7,28 @@ RUN docker-apt-install build-essential\
                        g++-$GNUCOMPILER \
                        gcc-$GNUCOMPILER \
                        gfortran-$GNUCOMPILER \
-		               python3-dev \
-                       python3-all \
-                       ipython3 \
-                       python3-ipdb \
+		               python-dev \
+                       python-all \
+                       ipython \
+                       python-ipdb \
 		               wcslib-dev \
-                       python3-astropy \
-                       python3-casacore \
+                       python-astropy \
+                       python-casacore \
                        casacore-data \
                        curl \
                        wget \
                        rsync \
-                       python3-pycurl \
-                       python3-matplotlib \
-                       python3-numpy \
-                       python3-ephem \
+                       python-pycurl \
+                       python-matplotlib \
+                       python-numpy \
+                       python-ephem \
                        f2c \                                                               
                        libf2c2-dev \                                                       
                        bison \                                                             
                        flex \
-                       python3-urllib3 \
+                       python-urllib3 \
                        unzip \
-                       python3-nose
+                       python-nose
 
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$GNUCOMPILER 100 && \
     update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-$GNUCOMPILER 100 && \
@@ -38,8 +38,7 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$GNUCOMPILER 100
     update-alternatives --install /usr/bin/cpp cpp /usr/bin/g++-$GNUCOMPILER 100 && \
     update-alternatives --install /usr/bin/x86_64-linux-gnu-cpp x86_64-linux-gnu-cpp /usr/bin/g++-$GNUCOMPILER 100 && \
     update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-$GNUCOMPILER 100 && \
-    update-alternatives --install /usr/bin/x86_64-linux-gnu-gfortran x86_64-linux-gnu-gfortran /usr/bin/gfortran-$GNUCOMPILER 100 && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.6 100
+    update-alternatives --install /usr/bin/x86_64-linux-gnu-gfortran x86_64-linux-gnu-gfortran /usr/bin/gfortran-$GNUCOMPILER 100
 
 RUN mkdir -p /optsoft/bin && \
     mkdir -p /optsoft/lib && \
@@ -97,9 +96,8 @@ ENV ALBUSINSTALL /optsoft/ALBUS
 
 ## Configure Make custom paths .. should really convert this to cmake or something....
 RUN sed -i '15s/.*/export INSTALLDIR = '$(echo ${ALBUSINSTALL} | sed 's/\//\\\//g')'/' $ALBUSPATH/Makefile
-#### Ubuntu 18.04 ships Python 3.6 LTS not 3.8 as it is defined in the build system
-RUN sed -i '19s/.*/export CURRENT_PYTHON = python3.6/' $ALBUSPATH/Makefile
-RUN sed -i '22s/.*/export PYTHONINCLUDEDIR = \/usr\/include\/python3.6/' $ALBUSPATH/Makefile
+RUN sed -i '19s/.*/export CURRENT_PYTHON = python2.7/' $ALBUSPATH/Makefile
+RUN sed -i '22s/.*/export PYTHONINCLUDEDIR = \/usr\/include\/python2.7/' $ALBUSPATH/Makefile
 #### Build with specified GNU toolchain
 RUN sed -i '39s/.*/export CC = gcc-'"${GNUCOMPILER}"'/' $ALBUSPATH/Makefile
 RUN sed -i '40s/.*/export F77 = gfortran-'"${GNUCOMPILER}"' --std=legacy/' $ALBUSPATH/Makefile
@@ -131,7 +129,7 @@ ENV PYTHONPATH "$ALBUSINSTALL/share/python:$ALBUSINSTALL/lib:$PYTHONPATH"
 # Step 4 Fingers crossed -- build
 WORKDIR $ALBUSPATH
 RUN make install
-RUN python -c "import AlbusIonosphere" && echo "Crack the bubbly - this hog is airborne!!!"
+RUN python2.7 -c "import AlbusIonosphere" && echo "Crack the bubbly - this hog is airborne!!!"
 
 # can run any script mounted inside the container py calling (assuming you run Bash or equiv.)
 # docker run -v <absolute path to gfzrnx>:/optsoft/bin/gfzrnx \
@@ -144,7 +142,7 @@ RUN python -c "import AlbusIonosphere" && echo "Crack the bubbly - this hog is a
 # you must download and accept the license for gfzrnx separately 
 # see https://dataservices.gfz-potsdam.de/panmetaworks/showshort.php?id=escidoc:1577894
 # Note: adding -it in the flags above should give you an interactive python session
-ENTRYPOINT [ "/usr/bin/python3.6" ]
+ENTRYPOINT [ "/usr/bin/python2.7" ]
 # print some default stuffs
 ENV HELPSTRING "docker run -v <absolute path to gfzrnx>:/optsoft/bin/gfzrnx "\
 "-v <absolute path to your waterhole with scripts>:/albus_waterhole "\

--- a/README.md
+++ b/README.md
@@ -36,13 +36,10 @@ taking into account modern understanding of ionospheric physics, and employs a
 model of the terrestrial magnetic field that accounts for change of intensity
 and direction with height.
 
-The software makes extensive use of python scripts and should work with both
-python2 and python3.
-
-You need to install pycurl, astropy, pyephem or python casacore, numpy 
-and matplotlib for the system to work. A number of support programs to handle 
-RINEX files are also needed. These programs are specified in the INSTALL 
-file.
+This software currently only gives expected results under Python 2.7. We have
+discovered yet-to-be-resolved numerical errors in deriving STEC values under
+Python 3.x. We highly recommend the user deploys an installation using the 
+provided Dockerfile.
 
 More sites (especially Geosciences Australia) are now producing only RINEX3 files. 
 For analysis, we use RINEX2 files. To convert RINEX3 to RINEX2 you need to get 
@@ -54,6 +51,35 @@ Unfortunately, due to security concerns, sites are also changing access methods
 from simple anonymous ftp to more secure procedures such as sftp etc and we are
 currently working on modifying our access procedures to reach such sites.
 secure access procedures 
+
+# Deployment using Docker
+We have provided a Docker file with the necessary install requirements for
+the software aside from the propriatary RINEXv3 utility gfzrnx, which have to be downloaded and mounted in 
+separately (see https://dataservices.gfz-potsdam.de/panmetaworks/showshort.php?id=escidoc:1577894
+for download and EULA agreement - this may not be distributed otherwise)
+```
+docker run -v <absolute path to gfzrnx>:/optsoft/bin/gfzrnx \
+           -v <absolute path to your waterhole with scripts>:/albus_waterhole \
+           --workdir /albus_waterhole \
+           --rm \
+           --user $(id -u <your user>):$(id -g <your user>) \
+           albus:latest <path to script mounted inside the waterhole>
+```
+if you used 'albus' as a tag when building the image, e.g. running
+```
+docker build -t albus -f Dockerfile . 
+```
+from inside the checked out albus folder
+
+Important note: If you have previously run a local build it will be wise to run Make clean
+to ensure that the right glibc and gfortran libraries are bound to your build inside
+the image.
+
+# Manual installation
+You need to install pycurl, astropy, pyephem or python casacore, numpy 
+and matplotlib for the system to work. A number of support programs to handle 
+RINEX files are also needed. These programs are specified in the INSTALL 
+file.
 
 A somewhat more detained description of the software is given in 
 the, as yet, unpublished paper twillis_ALBUS_paper.pdf available in 

--- a/acceptance_tests/test_rinex_autodownload_convert_v2_sutherland_mk_vla.py
+++ b/acceptance_tests/test_rinex_autodownload_convert_v2_sutherland_mk_vla.py
@@ -7,7 +7,7 @@
 # ionosphere rotation measure (RM) as a function of time
 
 # Example by Tony Willis
-
+from __future__ import print_function
 import os
 import time
 import matplotlib
@@ -65,7 +65,7 @@ def __checkmake_outputdir():
         if not os.path.exists(outputhiddendir):
             os.mkdir(outputhiddendir)
     else:
-        raise RuntimeError(f"'{testoutdir}' must be a valid directory -- are you running inside Docker, check mount path?")
+        raise RuntimeError("'%s' must be a valid directory -- are you running inside Docker, check mount path?" % testoutdir)
     return outputhiddendir
 
 def test_sutherland():

--- a/acceptance_tests/test_rinex_autodownload_mk_moon.py
+++ b/acceptance_tests/test_rinex_autodownload_mk_moon.py
@@ -7,7 +7,7 @@
 # ionosphere rotation measure (RM) as a function of time
 
 # Example by Tony Willis
-
+from __future__ import print_function
 import os
 import time
 import matplotlib
@@ -61,7 +61,7 @@ def __checkmake_outputdir():
         if not os.path.exists(outputhiddendir):
             os.mkdir(outputhiddendir)
     else:
-        raise RuntimeError(f"'{testoutdir}' must be a valid directory -- are you running inside Docker, check mount path?")
+        raise RuntimeError("'%s' must be a valid directory -- are you running inside Docker, check mount path?" % testoutdir)
     return outputhiddendir
 
 def test_meerkat():

--- a/python_scripts/Albus_Coordinates.py
+++ b/python_scripts/Albus_Coordinates.py
@@ -2,7 +2,7 @@
 # Python stuff for dealing with coordinate system conversions
 # 2006 Jun 22  James M Anderson  --JIVE  start
 # 2007 Jan 17  JMA  --add conversion from radians to degrees, min, sec
-
+from __future__ import (print_function, division)
 
 
 ################################################################################

--- a/python_scripts/Albus_RINEX.py
+++ b/python_scripts/Albus_RINEX.py
@@ -2,7 +2,7 @@
 # Python stuff for dealing with Ionosphere RINEX stuff
 # 2006 Jul 17  James M Anderson  --JIVE  start
 
-#from __future__ import (print_function)
+from __future__ import (print_function, division)
 
 ################################################################################
 # some import commands  The User should not need to change this.
@@ -1652,7 +1652,7 @@ station_bias_CODE_monthly  I  dictionary for station biases from CODE monthly
     TEC_scale_correct = 40.28 * 2.0 / IONOSPHERE_Kp_2
     nu_L1 = 1575.42E6          # GPS value, in Hz
     nu_L2 = nu_L1 * 60.0/77.0  # GPS value, in Hz
-    GPS_freq_factor = nu_L1*nu_L1*nu_L2*nu_L2 / (nu_L1*nu_L1 - nu_L2*nu_L2)
+    GPS_freq_factor = nu_L1*nu_L1*nu_L2*nu_L2 / float(nu_L1*nu_L1 - nu_L2*nu_L2)
 
     for sat in range(STEC.shape[1]):
         # satellite
@@ -1674,11 +1674,11 @@ station_bias_CODE_monthly  I  dictionary for station biases from CODE monthly
             nu_G1 = 1600.0E6
             nu_G2 = nu_G1 * 7.0/9.0
             GLONASS_freq_factor = nu_G1*nu_G1*nu_G2*nu_G2
-            GLONASS_freq_factor /= (nu_G1*nu_G1 - nu_G2*nu_G2)
+            GLONASS_freq_factor /= float(nu_G1*nu_G1 - nu_G2*nu_G2)
             STEC_factor = 2.0 / IONOSPHERE_Kp_2 * GLONASS_freq_factor * 1E-16
             ## The GPSTK software does not account for the
             ## frequency difference properly
-            freq_correction = GLONASS_freq_factor / GPS_freq_factor
+            freq_correction = GLONASS_freq_factor / float(GPS_freq_factor)
         elif(sat < 300):
             # Galileo
             this_station_code = station_code + '_e'
@@ -1689,7 +1689,7 @@ station_bias_CODE_monthly  I  dictionary for station biases from CODE monthly
             STEC_factor = 2.0 / IONOSPHERE_Kp_2 * Galileo_freq_factor * 1E-16
             ## The GPSTK software does not account for the
             ## frequency difference properly
-            freq_correction = Galileo_freq_factor / GPS_freq_factor
+            freq_correction = Galileo_freq_factor / float(GPS_freq_factor)
         else:
             raise KeyError("Unknown satellite type")
         if(this_station_code in station_bias_IONEX):
@@ -2047,7 +2047,7 @@ value       I  value to bracket
         return 0
     top = size-2
     bottom = 0
-    index = int(size/2)
+    index = int(size * 0.5)
     while(1):
         if(data[index] <= value):
             # index should be no lower
@@ -2057,7 +2057,7 @@ value       I  value to bracket
             top = index
         if((top == bottom) or ((top - bottom) == 1)):
             return bottom
-        index = int((top+bottom+1)/2)
+        index = int((top+bottom+1) * 0.5)
     # stop Xemacs bugginess
     return
 
@@ -2356,11 +2356,11 @@ target_STEC   O  The STEC in the direction of the target, using the mean_VTEC
         else:
             break
     if(sum_weight > 0.0):
-        mean_VTEC = sum / sum_weight
+        mean_VTEC = sum / float(sum_weight)
     else:
         warnings.warn("No points within max separation %E, using first point"%max_dist)
         mean_VTEC = get_VTEC_factor(L[0][2], iono_height, obs_height) * L[0][3]
-    target_STEC = mean_VTEC / get_VTEC_factor(El_target, iono_height, obs_height)
+    target_STEC = mean_VTEC / float(get_VTEC_factor(El_target, iono_height, obs_height))
     #print ( "I got mean_VTEC,target_STEC", mean_VTEC, target_STEC)
     return mean_VTEC, target_STEC
 
@@ -2451,10 +2451,10 @@ index         O  The index for the target MJD, to be used to feed the next
     if(math.fabs(MJD[index+1] - MJD_target) < 0.5*DAYS_PER_SECOND):
         return mean_VTEC_top, targ_STEC_top, index
     # Interpolate VTEC
-    slope = (mean_VTEC_top - mean_VTEC_bot) / (MJD[index+1] - MJD[index])
+    slope = (mean_VTEC_top - mean_VTEC_bot) / float(MJD[index+1] - MJD[index])
     mean_VTEC = mean_VTEC_bot + slope * (MJD_target - MJD[index])
     # convert to STEC
-    target_STEC = mean_VTEC / get_VTEC_factor(El_target, iono_height, obs_height)
+    target_STEC = mean_VTEC / float(get_VTEC_factor(El_target, iono_height, obs_height))
     #print ( "I got mean_VTEC,target_STEC, index", mean_VTEC, target_STEC, index)
     return mean_VTEC, target_STEC, index
 

--- a/python_scripts/Albus_RINEX_2.py
+++ b/python_scripts/Albus_RINEX_2.py
@@ -4,7 +4,7 @@
 # 2007 Feb 14  JMA  --revise RINEX reader to accept MJD check
 # 2007 Apr 18  JMA  --updates for more satellite block position handling
 
-from __future__ import (print_function)
+from __future__ import (print_function, division)
 
 ################################################################################
 # some import commands  The User should not need to change this.
@@ -394,7 +394,7 @@ XYZ        O  Cartesian station position in Earth centered coodriantes, in m
                         interval_undersampled = int(data_interval/interval)-1
             elif(line[60:79] == "# / TYPES OF OBSERV"):
                 num_data = int(line[0:6])
-                lines_per_sat = int((num_data-1)/5) +1
+                lines_per_sat = int((num_data-1)/5.) +1
                 obs_info = [None]*num_data
                 obs_info_code = [None]*num_data
                 line_pos = 0
@@ -498,7 +498,7 @@ XYZ        O  Cartesian station position in Earth centered coodriantes, in m
                 second = second + time_offset
                 MJD_now = jma_tools.get_MJD_hms(year, month, day,
                                                hour, minute, second)
-                index_f = (MJD_now - MJD_start) / interval
+                index_f = (MJD_now - MJD_start) / float(interval)
                 time_index = int(index_f + 0.25)
                 if(math.fabs(index_f - time_index) > 0.1):
                     # Hey, this does not match the time interval!  Some
@@ -631,7 +631,7 @@ XYZ        O  Cartesian station position in Earth centered coodriantes, in m
                 MJD_end -= 1.0
         else:
             MJD_end = MJD_start + 1
-        num = int((MJD_end - MJD_start) / interval + 0.25)
+        num = int((MJD_end - MJD_start) / float(interval) + 0.25)
         return read_RINEX_obs_file(filename, MJD_check, num, max_sat)
     return MJD, Sat_array, obs_data, time_offset, XYZ
 
@@ -779,7 +779,7 @@ t_02           O  r phase offset
         d_sum = slope.sum()
         if(d_sum == 0.0):
             break
-        change = -chi_2 / d_sum
+        change = -chi_2 / float(d_sum)
         if(math.fabs(change) > 0.2 * T_day):
             if(change > 0.0):
                 change = 0.2 * T_day
@@ -791,7 +791,7 @@ t_02           O  r phase offset
             slope = -2.0 * diff * c_term
             d_sum = slope.sum()
             if(d_sum != 0.0):
-                c2 = -chi_2 / d_sum * (j-5) / j
+                c2 = -chi_2 / d_sum * (j-5) / float(j)
         a2 = c2 * 0.05 * factor
         #print ( "%2d %12.4E %10.4f %10.2E %10.4f %10.4f %12.3E %12.3E %12.3E %10.4f"%(j, i_0, t_00, chi_2, change, app, i, c2, a2,factor))
         last_i = i
@@ -868,14 +868,14 @@ t_02           O  r phase offset
         d_sum = slope.sum()
         if(d_sum == 0.0):
             break
-        change = -chi_2 / d_sum
+        change = -chi_2 / float(d_sum)
         app = change * factor
         c2 = 0.0
         if(j>5):
             slope = -2.0 * diff * c_term
             d_sum = slope.sum()
             if(d_sum != 0.0):
-                c2 = -chi_2 / d_sum * (j-5) / j
+                c2 = -chi_2 / float(d_sum) * (j-5) / float(j)
         a2 = c2 * 0.05 * factor
         #print ( "%2d %12.4E %10.4f %10.2E %10.4f %10.4f %12.3E %12.3E %12.3E %10.4f"%(j, r_0, t_02, chi_2, change, app, r_A, c2, a2,factor))
         last_t_02 = t_02
@@ -943,7 +943,7 @@ obs_data   O  The output data array, as
             # things are ok
             pass
         else:
-            warnigns.warn("Unknown SP3 version '%s' in file '%s', trying anyway ...."%(version, filename))
+            warnings.warn("Unknown SP3 version '%s' in file '%s', trying anyway ...."%(version, filename))
         if(line[2] != 'P'):
             warnings.warn("Not a position file for '%s', trying anyway ...."%filename)
         year = int(line[3:7])
@@ -1106,7 +1106,7 @@ XYZ         O  numpy array of the satellite position
                     ho = MJD[index_start+i]-MJD_need
                     hp = MJD[index_start+i+m]-MJD_need
                     w = work_c[i+1]-work_d[i]
-                    den = w / (ho-hp)
+                    den = w / float(ho-hp)
                     work_d[i] = hp*den
                     work_c[i] = ho*den
                 if(2*ns+2 < (num_terms-m)):
@@ -1157,7 +1157,7 @@ index_start O  The index to use for interpolation over many values
 """
     assert(width>0)
     assert(width <= MAX)
-    half = int(width/2)
+    half = int(width * 0.5)
     index_start = index-half
     if(index_start < 0):
         index_start = 0
@@ -1214,18 +1214,18 @@ XYZ         O  numpy array of the satellite positions
         # Get the residuals to the measured orbits
         pos_res = sat_pos[:,s,:].copy()
         pos_res = np.reshape(pos_res, (NUM_OBS,1,NUM_DIR))
-        inside = 2.0*math.pi * (MJD-orbital_param[9])/orbital_param[2]
+        inside = 2.0*math.pi * (MJD-orbital_param[9])/float(orbital_param[2])
         pos_res[:,0,3] += - orbital_param[5] - orbital_param[6] * np.cos(inside)
-        inside = 4.0*math.pi * (MJD-orbital_param[8])/orbital_param[2]
+        inside = 4.0*math.pi * (MJD-orbital_param[8])/float(orbital_param[2])
         pos_res[:,0,4] += - orbital_param[3] - 2.0 * math.pi * (1.0/orbital_param[2] - 1.0) * MJD - orbital_param[4] * np.cos(inside)
-        inside = 2.0*math.pi * (MJD-orbital_param[7])/orbital_param[2]
+        inside = 2.0*math.pi * (MJD-orbital_param[7])/float(orbital_param[2])
         pos_res[:,0,5] += - 0.5*math.pi - orbital_param[0] * np.cos(inside) - orbital_param[1]
         # Get the predicted orbit values
-        inside = 2.0*math.pi * (MJD_need-orbital_param[9])/orbital_param[2]
+        inside = 2.0*math.pi * (MJD_need-orbital_param[9])/float(orbital_param[2])
         XYZ[:,s,3] = orbital_param[5] + orbital_param[6] * np.cos(inside)
-        inside = 4.0*math.pi * (MJD_need-orbital_param[8])/orbital_param[2]
+        inside = 4.0*math.pi * (MJD_need-orbital_param[8])/float(orbital_param[2])
         XYZ[:,s,4] = orbital_param[3] + 2.0 * math.pi * (1.0/orbital_param[2] - 1.0) * MJD_need + orbital_param[4] * np.cos(inside)
-        inside = 2.0*math.pi * (MJD_need-orbital_param[7])/orbital_param[2]
+        inside = 2.0*math.pi * (MJD_need-orbital_param[7])/float(orbital_param[2])
         XYZ[:,s,5] = 0.5*math.pi + orbital_param[0] * np.cos(inside) + orbital_param[1]
         # Now form the interpolated corrections
         index = None
@@ -1333,7 +1333,7 @@ El         O  Elevation angle, in radians
     r_sat = sat_XYZ[3]
     dot_p = sat_XYZ[0]*sta_XYZ[0]+sat_XYZ[1]*sta_XYZ[1]+sat_XYZ[2]*sta_XYZ[2]
     try:
-        zenith_angle = math.acos(dot_p/(r_sta*r_sat))
+        zenith_angle = math.acos(dot_p/float(r_sta*r_sat))
     except ArithmeticError:
         if(dot_p > 0.0):
             zenith_angle = 0.0
@@ -1346,7 +1346,7 @@ El         O  Elevation angle, in radians
     dec = math.pi*0.5 - sat_XYZ[5]
     phi = math.pi*0.5 - sta_XYZ[5]
     h = sta_XYZ[4] - sat_XYZ[4]
-    x = sat_XYZ[2]/r_sat*math.cos(phi)-math.cos(dec)*math.cos(h)*sta_XYZ[2]/r_sat
+    x = sat_XYZ[2]/float(r_sat)*math.cos(phi)-math.cos(dec)*math.cos(h)*sta_XYZ[2]/float(r_sat)
     y = -math.cos(dec) * math.sin(h)
     try:
         Az = math.atan2(y,x)
@@ -1557,17 +1557,17 @@ OUTPUTS: None
                 # but since they are close to each other, the error in assuming
                 # they are the same for the sigma calculation is small.
                 if((sat >= 0)and(sat < 100)):
-                    STEC = (L1/nu_L1_GPS - L2/nu_L2_GPS)
+                    STEC = (L1/float(nu_L1_GPS) - L2/float(nu_L2_GPS))
                     STEC *= SPEED_OF_LIGHT*STEC_factor_GPS
-                    sigma *= SPEED_OF_LIGHT*STEC_factor_GPS/nu_L2_GPS
+                    sigma *= SPEED_OF_LIGHT*STEC_factor_GPS/float(nu_L2_GPS)
                 elif((sat >= 100)and(sat < 200)):
-                    STEC = (L1/nu_G1_GLONASS - L2/nu_G2_GLONASS)
+                    STEC = (L1/float(nu_G1_GLONASS) - L2/float(nu_G2_GLONASS))
                     STEC *= SPEED_OF_LIGHT*STEC_factor_GLONASS
-                    sigma *= SPEED_OF_LIGHT*STEC_factor_GLONASS/nu_G2_GLONASS
+                    sigma *= SPEED_OF_LIGHT*STEC_factor_GLONASS/float(nu_G2_GLONASS)
                 elif((sat >= 200)and(sat < 300)):
-                    STEC = (L1/nu_E1_Gal - L2/nu_E5_Gal)
+                    STEC = (L1/float(nu_E1_Gal) - L2/float(nu_E5_Gal))
                     STEC *= SPEED_OF_LIGHT*STEC_factor_Gal
-                    sigma *= SPEED_OF_LIGHT*STEC_factor_Gal/nu_E5_Gal
+                    sigma *= SPEED_OF_LIGHT*STEC_factor_Gal/float(nu_E5_Gal)
                 else:
                     raise Albus_RINEX.RINEX_Data_Barf("Unknown satellite type %d"%sat)
                 obs_data[i,s, TL_pos] = STEC
@@ -1943,8 +1943,8 @@ TL_pos     I  Position in obs_data array for L data
 
 OUTPUTS: None
     """
-    Num_1 = adiff / nu_1_slip
-    Num_2 = adiff / nu_2_slip
+    Num_1 = adiff / float(nu_1_slip)
+    Num_2 = adiff / float(nu_2_slip)
     # int truncates!
     diff_1 = int(Num_1*2.0 + 0.5)*0.5 - Num_1
     diff_2 = int(Num_2*2.0 + 0.5)*0.5 - Num_2
@@ -2029,11 +2029,11 @@ block_pos  O  An array of continguous block position ranges, as 2 element
     TP_pos = _DATA_POS['STECP']
     TL_pos = _DATA_POS['STECL']
     if(sat < 100):
-        nu_1_slip = SPEED_OF_LIGHT * STEC_factor_GPS / nu_L1_GPS
-        nu_2_slip = SPEED_OF_LIGHT * STEC_factor_GPS / nu_L2_GPS
+        nu_1_slip = SPEED_OF_LIGHT * STEC_factor_GPS / float(nu_L1_GPS)
+        nu_2_slip = SPEED_OF_LIGHT * STEC_factor_GPS / float(nu_L2_GPS)
     elif(sat < 200):
-        nu_1_slip = SPEED_OF_LIGHT * STEC_factor_GLONASS / nu_G1_GLONASS
-        nu_2_slip = SPEED_OF_LIGHT * STEC_factor_GLONASS / nu_G2_GLONASS
+        nu_1_slip = SPEED_OF_LIGHT * STEC_factor_GLONASS / float(nu_G1_GLONASS)
+        nu_2_slip = SPEED_OF_LIGHT * STEC_factor_GLONASS / float(nu_G2_GLONASS)
     else:
         nu_1_slip = None
         nu_2_slip = None
@@ -2169,8 +2169,8 @@ block_pos  O  An array of continguous block position ranges, as 2 element
                     lower_intercept = obs_data[this_end-1,Sat_array[this_end-1,sat], TL_pos]
                 diff = upper_intercept - lower_intercept
                 adiff = math.fabs(diff)
-                Num_1 = adiff / nu_1_slip
-                Num_2 = adiff / nu_2_slip
+                Num_1 = adiff / float(nu_1_slip)
+                Num_2 = adiff / float(nu_2_slip)
                 # int truncates!
                 diff_1 = int(Num_1*2.0 + 0.5)*0.5 - Num_1
                 diff_2 = int(Num_2*2.0 + 0.5)*0.5 - Num_2
@@ -2261,11 +2261,11 @@ block_pos  O  An array of continguous block position ranges, as 2 element
     TP_pos = _DATA_POS['STECP']
     TL_pos = _DATA_POS['STECL']
     if(sat < 100):
-        nu_1_slip = SPEED_OF_LIGHT * STEC_factor_GPS / nu_L1_GPS
-        nu_2_slip = SPEED_OF_LIGHT * STEC_factor_GPS / nu_L2_GPS
+        nu_1_slip = SPEED_OF_LIGHT * STEC_factor_GPS / float(nu_L1_GPS)
+        nu_2_slip = SPEED_OF_LIGHT * STEC_factor_GPS / float(nu_L2_GPS)
     elif(sat < 200):
-        nu_1_slip = SPEED_OF_LIGHT * STEC_factor_GLONASS / nu_G1_GLONASS
-        nu_2_slip = SPEED_OF_LIGHT * STEC_factor_GLONASS / nu_G2_GLONASS
+        nu_1_slip = SPEED_OF_LIGHT * STEC_factor_GLONASS / float(nu_G1_GLONASS)
+        nu_2_slip = SPEED_OF_LIGHT * STEC_factor_GLONASS / float(nu_G2_GLONASS)
     else:
         nu_1_slip = None
         nu_2_slip = None
@@ -2302,8 +2302,8 @@ block_pos  O  An array of continguous block position ranges, as 2 element
             last_L = L
     if(num < 2):
         return sat_found, block_pos
-    ave = sum / num
-    std_dev = (sum_sqr - sum*sum / num) / (num-1)
+    ave = sum / float(num)
+    std_dev = (sum_sqr - sum*sum / float(num)) / (num-1)
     if(std_dev > 0.0):
         std_dev = math.sqrt(std_dev)
     else:
@@ -2481,7 +2481,7 @@ sat_block_pos O  An array of continguous block position ranges, as 3 element
                     count += 1
             average = np.zeros((1), dtype='float64')
             if(count):
-                average[0] = sum/count
+                average[0] = sum/float(count)
                 total_sat_count += 1
             else:
                 average[0] = BAD_DATA_CODE
@@ -2511,7 +2511,7 @@ sat_block_pos O  An array of continguous block position ranges, as 3 element
             if(sum_weight == 0.0):
                 # no data here
                 continue
-            diff_ave = sum_diff / sum_weight
+            diff_ave = sum_diff / float(sum_weight)
             if(end_pos > start_pos+1):
                 diff_var = (sum_d2 - sum_diff*sum_diff / sum_weight) / sum_weight
                 if(diff_var < 0.0):
@@ -3742,7 +3742,7 @@ overwrite    I  May files be overwritten?  0 No, else yes
 OUTPUTS: None
     """
     assert(len(sta_XYZ) == 6)
-    BIAS_LENGTH = int(MAX_POSSIBLE_SATELLITES/100)
+    BIAS_LENGTH = int(MAX_POSSIBLE_SATELLITES/float(100))
     assert(len(sta_bias_valid) == BIAS_LENGTH)
     filename = "%s/%s.%d.%d.XYZ"%(output_directory,station_code,MJD_start,MJD_end)
     if(os.path.isfile(filename)):
@@ -4250,7 +4250,7 @@ get_multiple_station_base_observations.MJD_end_last    = 0.0
 ###########################
 ### MeqTree Area ##########
 
-MAX_POSSIBLE_MEQTREE_SATELLITES = MAX_POSSIBLE_SATELLITES / 2
+MAX_POSSIBLE_MEQTREE_SATELLITES = int(MAX_POSSIBLE_SATELLITES * 0.5)
 
 
 
@@ -4269,7 +4269,7 @@ M_s         O  The MeqTree satellite number.  Numbers >= 0 are valid.
                a value of -1 indicates that there is no valid MeqTree number
                corresponding to the RINEX number given.
     """
-    for mytype in range(MAX_POSSIBLE_SATELLITES/100):
+    for mytype in range(int(MAX_POSSIBLE_SATELLITES/float(100))):
         offset = sat_number - mytype*100
         if((offset >= 0) and (offset < 50)):
             M_s = mytype*50 + offset
@@ -4290,7 +4290,7 @@ R_s         O  The RINEX satellite number.  Numbers >= 0 are valid.
     """
     if(sat_number < 0):
         return -1
-    mytype = int(sat_number/50)
+    mytype = int(sat_number/50.)
     offset = sat_number - mytype*50
     R_s = offset + mytype*100
     if(R_s >= MAX_POSSIBLE_SATELLITES):

--- a/python_scripts/Albus_RINEX_download.py
+++ b/python_scripts/Albus_RINEX_download.py
@@ -5,8 +5,9 @@
 # I have made my own simple case
 # 2007 Jan 19  James M Anderson  --JIVE  start
 # 2020 Using pycurl with python3
-
-
+from __future__ import (print_function, division)
+import os
+SKIP_CACHED_DOWNLOAD = "ALBUS_NOCACHED_DOWNLOAD" in os.environ
 import sys
 import pycurl
 
@@ -16,6 +17,11 @@ def main():
         print("Error: correct usage is %s inURL, outfilename timeout"%sys.argv[0])
         sys.exit(-2)
     print('Albus_RINEX_download system parameters', sys.argv)
+    
+    if not SKIP_CACHED_DOWNLOAD and os.path.exists(sys.argv[2]):
+      print("Skipping %s -- already cached")
+      sys.exit(0)
+
     if sys.argv[1].find('sftp')> -1:
       use_pysftp = True
       try:

--- a/python_scripts/Albus_iono_object.py
+++ b/python_scripts/Albus_iono_object.py
@@ -1,3 +1,4 @@
+from __future__ import (print_function, division)
 import AlbusIonosphere
 
 class AlbusIono:

--- a/python_scripts/Albus_rnx3_to_rnx2.py
+++ b/python_scripts/Albus_rnx3_to_rnx2.py
@@ -1,3 +1,4 @@
+from __future__ import (print_function, division)
 import re, string
 import numpy as np
 import inspect

--- a/python_scripts/GPS_stations.py
+++ b/python_scripts/GPS_stations.py
@@ -743,9 +743,6 @@ A        O  List of 3 element arrays [station_name, station_position, dist],
     local_list = []
     global_list = [] 
     for s in stations:
-        if "dear" not in s:
-            print("Skipping %s station download" % s)
-            continue
 #       print s, stations[s]
         pos = stations[s]
         for XYZ in coord_list:

--- a/python_scripts/GPS_stations.py
+++ b/python_scripts/GPS_stations.py
@@ -8,7 +8,7 @@
 # http://igs.ifag.de/root_ftp/GREF/products/1378/bkg13787.snx.Z
 # Note that one should be available for each GPS week.
 
-
+from __future__ import (print_function,division)
 import os, os.path
 import math
 #from string import split, strip
@@ -743,6 +743,9 @@ A        O  List of 3 element arrays [station_name, station_position, dist],
     local_list = []
     global_list = [] 
     for s in stations:
+        if "dear" not in s:
+            print("Skipping %s station download" % s)
+            continue
 #       print s, stations[s]
         pos = stations[s]
         for XYZ in coord_list:

--- a/python_scripts/MS_Iono_agw_azel_par.py
+++ b/python_scripts/MS_Iono_agw_azel_par.py
@@ -2,7 +2,7 @@
 # script to predict ionosphere corrections at a specific pointing direction 
 # or at zenith (El = 90 deg)
 
-from __future__ import (print_function)
+from __future__ import (print_function,division)
 
 from MS_Iono_functions import * 
 

--- a/python_scripts/MS_Iono_agw_multi_dir.py
+++ b/python_scripts/MS_Iono_agw_multi_dir.py
@@ -1,4 +1,5 @@
 #
+from __future__ import (print_function,division)
 from MS_Iono_functions import *
 
 #########################################################################

--- a/python_scripts/MS_Iono_agw_multi_stn.py
+++ b/python_scripts/MS_Iono_agw_multi_stn.py
@@ -1,4 +1,5 @@
 
+from __future__ import (print_function,division)
 from MS_Iono_functions import * 
 
 # The following function should be the only one which needs changes that depend

--- a/python_scripts/MS_Iono_agw_par.py
+++ b/python_scripts/MS_Iono_agw_par.py
@@ -1,3 +1,4 @@
+from __future__ import (print_function,division)
 from MS_Iono_functions import * 
 
 # The following function should be the only one which needs changes that depend

--- a/python_scripts/MS_Iono_functions.py
+++ b/python_scripts/MS_Iono_functions.py
@@ -1,6 +1,6 @@
 # various fnctions for processing ionosphere data
 
-from __future__ import (print_function)
+from __future__ import (print_function,division)
 
 import math
 import numpy

--- a/python_scripts/MS_Iono_test.py
+++ b/python_scripts/MS_Iono_test.py
@@ -1,4 +1,4 @@
-
+from __future__ import (print_function)
 from MS_Iono_functions import * 
 
 # The following function should be the only one which needs changes that depend

--- a/python_scripts/compare_iono_results.py
+++ b/python_scripts/compare_iono_results.py
@@ -1,3 +1,4 @@
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/hampel.py
+++ b/python_scripts/hampel.py
@@ -1,3 +1,4 @@
+from __future__ import (print_function,division)
 import numpy
 from copy import deepcopy
 

--- a/python_scripts/hampel_filter_plot.py
+++ b/python_scripts/hampel_filter_plot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function,division)
 import os
 import sys
 import numpy

--- a/python_scripts/jma_tools.py
+++ b/python_scripts/jma_tools.py
@@ -3,7 +3,7 @@
 # 2006 May 19  James M Anderson  --JIVE  start
 # 2007 Jul 25  JMA  --many enhancements before now.  Today, allow
 #                     self-calibration to just use point-source calib
-
+from __future__ import (print_function, division)
 
 
 
@@ -110,8 +110,8 @@ Taken from _Astronomical Algorithms_, Meeus, 1991
     if(mm<= 2):
         mm += 12
         yy -= 1
-    a = int(yy/100)
-    b = 2 - a + int(a/4)
+    a = int(yy/100.)
+    b = 2 - a + int(a//4)
     MJD = int(365.25*(yy+4716)) + int(30.6001*(mm+1)) + day + b - 1524.5
     MJD -= 2400000.5
     return MJD
@@ -173,7 +173,7 @@ Taken from _Astronomical Algorithms_, Meeus, 1991
     A = Z
     if(Z>= 2299161):
         alpha = int((Z-1867216.25)/36524.25)
-        A = Z + 1 + alpha - int(alpha/4)
+        A = Z + 1 + alpha - int(alpha//4)
     B = A + 1524
     C = int((B-122.1)/365.25)
     D = int(365.25*C)

--- a/python_scripts/lenc_latlonxyz.py
+++ b/python_scripts/lenc_latlonxyz.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function, division)
 import math
 import ephem
 

--- a/python_scripts/plot_albus.py
+++ b/python_scripts/plot_albus.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/plot_albus_az.py
+++ b/python_scripts/plot_albus_az.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/plot_albus_diff_rm_hrs.py
+++ b/python_scripts/plot_albus_diff_rm_hrs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/plot_albus_diff_stec_hrs.py
+++ b/python_scripts/plot_albus_diff_stec_hrs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/plot_albus_elev_hrs.py
+++ b/python_scripts/plot_albus_elev_hrs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/plot_albus_multi_elev.py
+++ b/python_scripts/plot_albus_multi_elev.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/plot_albus_multi_rm.py
+++ b/python_scripts/plot_albus_multi_rm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/plot_albus_multi_stec.py
+++ b/python_scripts/plot_albus_multi_stec.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/plot_albus_rm_elev_hrs.py
+++ b/python_scripts/plot_albus_rm_elev_hrs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/plot_albus_rm_hrs.py
+++ b/python_scripts/plot_albus_rm_hrs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/plot_albus_rm_hrs1.py
+++ b/python_scripts/plot_albus_rm_hrs1.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/plot_albus_stec_hrs.py
+++ b/python_scripts/plot_albus_stec_hrs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/plot_albus_stuff.py
+++ b/python_scripts/plot_albus_stuff.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/plot_albus_tec_elev_hrs.py
+++ b/python_scripts/plot_albus_tec_elev_hrs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/plot_diffs.py
+++ b/python_scripts/plot_diffs.py
@@ -1,3 +1,4 @@
+from __future__ import (print_function)
 import matplotlib.pyplot as plt
 from astropy.visualization import astropy_mpl_style
 plt.style.use(astropy_mpl_style)

--- a/python_scripts/plot_double_stec.py
+++ b/python_scripts/plot_double_stec.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/plot_fits.py
+++ b/python_scripts/plot_fits.py
@@ -1,3 +1,4 @@
+from __future__ import (print_function)
 import matplotlib.pyplot as plt
 from astropy.visualization import astropy_mpl_style
 plt.style.use(astropy_mpl_style)

--- a/python_scripts/plot_multiple_TEC_values.py
+++ b/python_scripts/plot_multiple_TEC_values.py
@@ -2,6 +2,7 @@
 
 # a python script to read in two fits files containing L, M and N tracks
 # 2018/06/11 - comment - I have no idea what I was using this for !!
+from __future__ import (print_function)
 import os
 import sys
 import numpy

--- a/python_scripts/plot_smooth_rm.py
+++ b/python_scripts/plot_smooth_rm.py
@@ -1,3 +1,4 @@
+from __future__ import (print_function)
 import sys
 import numpy
 import math

--- a/python_scripts/proc_info.py
+++ b/python_scripts/proc_info.py
@@ -1,3 +1,4 @@
+from __future__ import (print_function)
 import platform, subprocess
 
 def get_processor_info():

--- a/python_scripts/test_iri.py
+++ b/python_scripts/test_iri.py
@@ -1,4 +1,4 @@
-
+from __future__ import (print_function)
 from MS_Iono_functions import * 
 
 # The following function should be the only one which needs changes that depend

--- a/python_scripts/test_mill.py
+++ b/python_scripts/test_mill.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import (print_function)
 import os
 import sys
 import numpy


### PR DESCRIPTION
- Workaround for #14

Currently there is a yet to be found numerical issue when building under Python3.x which is not related to a dependency version change or division change as far as I can tell

There is also a parsing error where ALBUS under 3.6 rejects stations other than the first station on the stations list from what I've noticed from flipping between versions. It is possible a change in behaviour with iterators or another parsing issue which I am yet to trace down.

These are two distinct unrelated problems (I can reproduce the numerical issue with the single same station at Upington), however I've at least for the time being put my mind at ease that we get sensible stec solutions from the 2.7 build.

I will continue to dig on the #15 PR as I get time but for now I strongly suggest we swap the python 3.x build out for a 2.7 only build @twillis449 - it may be blind luck that this has not been seen elsewhere - it does not appear to have anything to do with the particular station.

@o-smirnov please in the interm redo your build to switch to Python 2.7. @mamkhari please deploy this version for your MSc. work on MeerKAT CAM as discussed